### PR TITLE
Androidにてクロノスの石利用規約のmailto: が機能しない

### DIFF
--- a/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
+++ b/cocos/platform/android/java/src/org/cocos2dx/lib/Cocos2dxWebView.java
@@ -8,6 +8,8 @@ import android.webkit.WebChromeClient;
 import android.webkit.WebView;
 import android.webkit.WebViewClient;
 import android.widget.FrameLayout;
+import android.content.Intent;
+import android.net.Uri;
 
 import java.lang.reflect.Method;
 import java.net.URI;
@@ -93,6 +95,12 @@ public class Cocos2dxWebView extends WebView {
                     });
                     return true;
                 }
+
+                if (uri != null && uri.getScheme().equals("mailto")) {
+                    activity.startActivity(new Intent(Intent.ACTION_SENDTO, Uri.parse(urlString)));
+                    return true;
+                }
+
             } catch (Exception e) {
                 Log.d(TAG, "Failed to create URI from url");
             }


### PR DESCRIPTION
https://extra-jira.gree-office.net/browse/KMS-4236

AndroidのWebviewでmailtoが動くようにしました。